### PR TITLE
Upgrade rusqlite to version 0.25

### DIFF
--- a/schemer-rusqlite/Cargo.toml
+++ b/schemer-rusqlite/Cargo.toml
@@ -13,6 +13,6 @@ repository = "https://github.com/aschampion/schemer"
 
 [dependencies]
 uuid = { version = "1" }
-rusqlite = "0.24"
+rusqlite = "0.25"
 
 schemer = { version = "0.2.0", path = "../schemer" }

--- a/schemer-rusqlite/src/lib.rs
+++ b/schemer-rusqlite/src/lib.rs
@@ -169,7 +169,7 @@ impl<'a, E: From<RusqliteError> + Sync + Send + Error + 'static> Adapter
                 "INSERT INTO {} (id) VALUES (?1);",
                 self.migration_metadata_table
             ),
-            &[&uuid_bytes],
+            [&uuid_bytes],
         )?;
         trans.commit().map_err(|e| e.into())
     }
@@ -184,7 +184,7 @@ impl<'a, E: From<RusqliteError> + Sync + Send + Error + 'static> Adapter
                 "DELETE FROM {} WHERE id = ?1;",
                 self.migration_metadata_table
             ),
-            &[&uuid_bytes],
+            [&uuid_bytes],
         )?;
         trans.commit().map_err(|e| e.into())
     }


### PR DESCRIPTION
Hi, it would be handy to be able to use some of the changes that are available in the newer version of sqlite that 0.25 depends upon (specifically support for the RETURNING statement). If possible, it would be great to have a release that targets this version (pre-MSRV bump) and then I will submit a separate PR that upgrades to a current rusqlite version (which has an MSRV of 1.59)