### PR TITLE
Update daggy dependency

### DIFF
--- a/schemer/Cargo.toml
+++ b/schemer/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/aschampion/schemer"
 
 [dependencies]
-daggy = "0.6"
+daggy = "0.8"
 log = "0.4"
 thiserror = "1.0"
 uuid = { version = "1" }


### PR DESCRIPTION
We’re using schemer downstream, and the old daggy has an older petgraph
dependency that is causing duplicate libraries in our project. So upgrading to a
daggy that depends on a newer petgraph.