### PR TITLE
Upgrade to `rusqlite` 0.29.0 which mitigates RUSTSEC-2022-0090…

### DIFF
--- a/schemer-rusqlite/Cargo.toml
+++ b/schemer-rusqlite/Cargo.toml
@@ -13,6 +13,6 @@ repository = "https://github.com/aschampion/schemer"
 
 [dependencies]
 uuid = { version = "1" }
-rusqlite = "0.25"
+rusqlite = "0.29.0"
 
 schemer = { version = "0.2.1", path = "../schemer" }


### PR DESCRIPTION
See https://rustsec.org/advisories/RUSTSEC-2022-0090 for security advisory.

This was detected with `cargo install cargo-audit ; cargo audit`.

This resolves #19.

Note, I only verified unittests with `cargo test -p schemer-rusqlite` because I do not have postgres setup.