### PR TITLE
`schemer-rusqlite`: update doc example; exposes error

### DIFF
--- a/schemer-rusqlite/src/lib.rs
+++ b/schemer-rusqlite/src/lib.rs
@@ -4,16 +4,10 @@
 //! # Examples:
 //!
 //! ```rust
-//! extern crate rusqlite;
-//! #[macro_use]
-//! extern crate schemer;
-//! extern crate schemer_rusqlite;
-//! extern crate uuid;
-//!
 //! use std::collections::HashSet;
 //!
 //! use rusqlite::{params, Connection, Transaction, Error as RusqliteError};
-//! use schemer::{Migration, Migrator};
+//! use schemer::{Migration, Migrator, migration};
 //! use schemer_rusqlite::{RusqliteAdapter, RusqliteAdapterError, RusqliteMigration};
 //! use uuid::Uuid;
 //!
@@ -38,16 +32,14 @@
 //!     }
 //! }
 //!
-//! fn main() {
-//!     let mut conn = Connection::open_in_memory().unwrap();
-//!     let adapter = RusqliteAdapter::new(&mut conn, None);
+//! let mut conn = Connection::open_in_memory().unwrap();
+//! let adapter = RusqliteAdapter::new(&mut conn, None);
 //!
-//!     let mut migrator = Migrator::new(adapter);
+//! let mut migrator = Migrator::new(adapter);
 //!
-//!     let migration = Box::new(MyExampleMigration {});
-//!     migrator.register(migration);
-//!     migrator.up(None);
-//! }
+//! let migration = Box::new(MyExampleMigration {});
+//! migrator.register(migration).unwrap();
+//! migrator.up(None).unwrap();
 //! ```
 #![warn(clippy::all)]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
# Rationale

Ensure doc example uses modern rust, is automatically tested, and checks for errors.

# Summary

This PR updates the `schemer-rusqlite` doc example in three ways:

- It drops the `extern crate` and `#[macro_use]` statements to follow edition 2021 style.
- It moves the body of `main` to the top-level: this is very important because it ensure `cargo test` exercises the expressions.
- It calls `unwrap` on all results: this exposes an error!

# Exposed Error

```
$ cargo test -p schemer-rusqlite                                                                                                                                                                                   
    Finished test [unoptimized + debuginfo] target(s) in 0.03s                                                                                                                                                     
     Running unittests src/lib.rs (target/debug/deps/schemer_rusqlite-c8c258f066245d88)                                                                                                                            
                                                                                                                                                                                                                   
running 4 tests                                                                                                                                                                                                    
test tests::test_migration_chain ... ok                                                                                                                                                                            
test tests::test_single_migration ... ok                                                                                                                                                                           
test tests::test_branching_dag ... ok                                                                    
test tests::test_multi_component_dag ... ok                                                                                                                                                                        
                                                                                                         
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s                                                                                                                      
                                                                                                         
   Doc-tests schemer-rusqlite                                                                                                                                                                                      
                                                                                                         
running 2 tests                                                                                                                                                                                                    
test src/lib.rs - RusqliteAdapter<'a,E>::new (line 97) ... ok
test src/lib.rs - (line 6) ... FAILED                                                                                                                                                                              
                                                                                                         
failures:                                                                                                                                                                                                          
                                                                                                         
---- src/lib.rs - (line 6) stdout ----                                                                                                                                                                             
Test executable failed (exit status: 101).
stderr:                                                                                                                                                                                                   [39/1145]
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Adapter(SqliteFailure(Error { code: Unknown, extended_code: 1 }, Some("no such table: _schemer")))', src/lib.rs:40:19
stack backtrace: 
[… backtrace elided]

failures:                                                                                                
    src/lib.rs - (line 6)                                                                                                                                                                                          
                                                                                                         
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.74s                                                                                                                  
                                                                                                         
error: doctest failed, to rerun pass `-p schemer-rusqlite --doc`          
```

# Rendering

The rendered docs now look like this on my system: 
![image](https://github.com/aschampion/schemer/assets/4369700/44c32751-c87c-4d5a-982c-172dbc968e17)


