### PR TITLE
Update to support rusqlite 0.32

### DIFF
--- a/schemer-rusqlite/CHANGELOG.md
+++ b/schemer-rusqlite/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- next-header -->
 ## [Unreleased]
 
+### Changed
+- Updated rusqlite from 0.25 to 0.32.
 
 ## [0.2.2] - 2023-04-18
 ### Changed

--- a/schemer-rusqlite/Cargo.toml
+++ b/schemer-rusqlite/Cargo.toml
@@ -13,6 +13,6 @@ repository = "https://github.com/aschampion/schemer"
 
 [dependencies]
 uuid = { version = "1" }
-rusqlite = "0.29.0"
+rusqlite = "0.32"
 
 schemer = { version = "0.2.1", path = "../schemer" }


### PR DESCRIPTION
I've been wondering: would it make sense to create a release for each semver-incompatible rusqlite version? That way it's at least possible for users of the crate to get one that works with their stack.

@aschampion If it would be helpful I would like to offer to become a co-maintainer of the `schemer` and `schemer-rusqlite` crates on crates.io; I use these crates extensively both for work and personal projects, and would like to be able to make sure they work for as many users as possible.